### PR TITLE
Set level from command line

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,6 +1,6 @@
 use crate::device::Device;
 use std::process::Command;
-use std::thread;
+use std::thread::JoinHandle;
 
 pub struct Audio;
 
@@ -31,11 +31,11 @@ impl Device for Audio {
         output[a..b].parse().unwrap()
     }
 
-    fn set_level(&self, level: u64) {
-        thread::spawn(move || {
+    fn set_level(&self, level: u64) -> JoinHandle<()> {
+        std::thread::spawn(move || {
             Command::new("/usr/bin/amixer").
                 arg("set").arg("Master").arg(format!("{}%", level)).
                 output().expect("amixer not installed");
-        });
+        })
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,7 @@
+use std::thread::JoinHandle;
+
 pub trait Device {
     fn name(&self) -> String;
     fn level(&self) -> u64;
-    fn set_level(&self, level: u64);
+    fn set_level(&self, level: u64) -> JoinHandle<()>;
 }

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1,6 +1,6 @@
 use crate::device::Device;
 use std::process::Command;
-use std::thread;
+use std::thread::JoinHandle;
 
 pub struct Screen;
 
@@ -27,11 +27,11 @@ impl Device for Screen {
         output[0..n].parse().unwrap()
     }
 
-    fn set_level(&self, level: u64) {
-        thread::spawn(move || {
+    fn set_level(&self, level: u64) -> JoinHandle<()> {
+        std::thread::spawn(move || {
             Command::new("/usr/bin/xbacklight").
                 arg("-set").arg(level.to_string()).
                 output().expect("backlight not installed");
-        });
+        })
     }
 }


### PR DESCRIPTION
Invoking `level screen 10` will directly set screen level to 10% and exit.